### PR TITLE
Updated links to AOSEdge documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 AOS Python Sample Service
 
-Please read https://docs.aoscloud.io/bin/view/Home/Cookbooks/Get%20started/Create%20an%20Aos%20service/ to use the service on the AosEdge unit.
+Please read [AOSEdge Cookbook](https://docs.aoscloud.io/bin/view/Cookbooks/3.%20Create%20your%20first%20AosEdge%20service/) how to use the service on the AosEdge unit.

--- a/meta/config.yaml
+++ b/meta/config.yaml
@@ -45,4 +45,4 @@ configuration:
         # temp: 32KB
 
 # For additional information please visit the page:
-# https://docs.aoscloud.io/bin/view/Home/Architecture/General/Data%20formats/Service%20formats/Containers%20configuration%20file/
+# https://docs.aoscloud.io/bin/view/4.%20AosCore/AosEdge%20services/Services/Service%20formats/Containers%20configuration%20file/


### PR DESCRIPTION
While following [AOSEdge Cookbook](https://docs.aoscloud.io/bin/view/Cookbooks/) I stumbled over some outdated links - this PR shall fix at least two of them.